### PR TITLE
Endpoint setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.0</version>
+        <version>2.7.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -24,23 +24,21 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.13</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.6.4</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/example/takehometest/ServiceController.java
+++ b/src/main/java/com/example/takehometest/ServiceController.java
@@ -33,7 +33,8 @@ public class ServiceController {
 
   @GetMapping(value = "/get")
   public String get(@RequestParam String id) {
-    String url = booksPath + id + ".json";
+    String idProcessed = id.trim().replaceAll(" ", "_");
+    String url = booksPath + idProcessed + ".json";
     return processRequest(url);
   }
 

--- a/src/main/java/com/example/takehometest/ServiceController.java
+++ b/src/main/java/com/example/takehometest/ServiceController.java
@@ -1,6 +1,7 @@
 package com.example.takehometest;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,6 +12,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 @RestController
+@RequestMapping(value = "/rest-api/v1")
 public class ServiceController {
   @GetMapping(value = "/search")
   public String search(@RequestParam String text) throws IOException, InterruptedException {

--- a/src/main/java/com/example/takehometest/ServiceController.java
+++ b/src/main/java/com/example/takehometest/ServiceController.java
@@ -49,10 +49,8 @@ public class ServiceController {
       JsonNode node = mapper.readValue(json, JsonNode.class);
       JsonNode errorNode = node.get("error");
 
-      if (errorNode != null) {
-        return "{\"error\": \"An external service gave error (" + errorNode + ")\"}";
-      }
-      return response.body();
+      return errorNode != null ? "{\"error\": \"An external service gave error (" + errorNode + ")\"}" : response.body();
+
     } catch (IOException e) {
       return "{\"error\": \"Couldn't execute the request correctly due to data processing error\"}";
     } catch (InterruptedException e) {

--- a/src/main/java/com/example/takehometest/ServiceController.java
+++ b/src/main/java/com/example/takehometest/ServiceController.java
@@ -17,24 +17,29 @@ import java.net.http.HttpResponse;
 @RestController
 @RequestMapping(value = "/api/v1")
 public class ServiceController {
-  @Value("${service.url}")
-  private String reqUrl;
+  @Value("${external.url.openlibrary}")
+  private String baseUrl;
+  @Value("${external.url.openlibrary.search}")
+  private String searchPath;
+  @Value("${external.url.openlibrary.books}")
+  private String booksPath;
+
   @GetMapping(value = "/search")
   public String search(@RequestParam String text) {
     String textProcessed = text.replaceAll(" ", "+");
-    String url = "/search.json?q=" + textProcessed;
+    String url = searchPath + textProcessed;
     return processRequest(url);
   }
 
   @GetMapping(value = "/get")
   public String get(@RequestParam String id) {
-    String url = "/books/" + id + ".json";
+    String url = booksPath + id + ".json";
     return processRequest(url);
   }
 
   private String processRequest(String url) {
     HttpClient client = HttpClient.newHttpClient();
-    URI uri = URI.create(reqUrl + url);
+    URI uri = URI.create(baseUrl + url);
     HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
     try {
       HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
@@ -44,13 +49,13 @@ public class ServiceController {
       JsonNode node = mapper.readValue(json, JsonNode.class);
       JsonNode errorNode = node.get("error");
 
-      if(errorNode != null) {
+      if (errorNode != null) {
         return "{\"error\": \"An external service gave error (" + errorNode + ")\"}";
       }
       return response.body();
-    } catch(IOException e) {
+    } catch (IOException e) {
       return "{\"error\": \"Couldn't execute the request correctly due to data processing error\"}";
-    } catch(InterruptedException e) {
+    } catch (InterruptedException e) {
       return "{\"error\": \"The request was interrupted\"}";
     }
   }

--- a/src/main/java/com/example/takehometest/ServiceController.java
+++ b/src/main/java/com/example/takehometest/ServiceController.java
@@ -1,5 +1,6 @@
 package com.example.takehometest;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,12 +15,14 @@ import java.net.http.HttpResponse;
 @RestController
 @RequestMapping(value = "/rest-api/v1")
 public class ServiceController {
+  @Value("${service.url}")
+  private String reqUrl;
   @GetMapping(value = "/search")
   public String search(@RequestParam String text) throws IOException, InterruptedException {
     System.out.println(text);
     String textProcessed = text.replaceAll(" ", "+");
     HttpClient client = HttpClient.newHttpClient();
-    String url = "http://openlibrary.org/search.json?q=" + textProcessed;
+    String url = reqUrl + "/search.json?q=" + textProcessed;
     URI uri = URI.create(url);
     HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
     HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
@@ -30,7 +33,7 @@ public class ServiceController {
   public String get(@RequestParam String id) throws IOException, InterruptedException {
     System.out.println(id);
     HttpClient client = HttpClient.newHttpClient();
-    String url = "https://openlibrary.org/books/" + id + ".json";
+    String url = reqUrl + "/books/" + id + ".json";
     URI uri = URI.create(url);
     HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
     HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/main/java/com/example/takehometest/ServiceController.java
+++ b/src/main/java/com/example/takehometest/ServiceController.java
@@ -15,8 +15,9 @@ public class ServiceController {
   @GetMapping(value = "/search")
   public String search(@RequestParam String text) throws IOException, InterruptedException {
     System.out.println(text);
+    String textProcessed = text.replaceAll(" ", "+");
     HttpClient client = HttpClient.newHttpClient();
-    String url = "http://openlibrary.org/search.json?q=" + text;
+    String url = "http://openlibrary.org/search.json?q=" + textProcessed;
     URI uri = URI.create(url);
     HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
     HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+service.url = https://openlibrary.org

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-service.url = https://openlibrary.org
+external.url.openlibrary = https://openlibrary.org
+external.url.openlibrary.search = /search.json?q=
+external.url.openlibrary.books = /books/


### PR DESCRIPTION
This pull request will implement a facade layer for two endpoints
* /search?text=the+lord+of+the+rings
  * that will call http://openlibrary.org/search.json?q=the+lord+of+the+rings
* /get?id=OL9158246M
  * that will call https://openlibrary.org/books/OL9158246M.json
* Added error handling for invalid "text" searches, invalid "id" for books, and responses that return error's
* Response is returned as JSON